### PR TITLE
add installed_paths instruction to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The project implements [Cognitive Complexity metric by SonarSource](https://www.
 ```bash
 composer init --no-interaction
 composer require rarst/phpcs-cognitive-complexity squizlabs/php_codesniffer dealerdirect/phpcodesniffer-composer-installer
+vendor/bin/phpcs --config-set installed_paths vendor/rarst/phpcs-cognitive-complexity/src/CognitiveComplexity
 vendor/bin/phpcs --standard=CognitiveComplexity /path/to/scan
 ```
 


### PR DESCRIPTION
The PR for this branch just adds one line to the installation instructions that was necessary in my case.

**Issue**
When running the check, I ran into an error:
$ `vendor/bin/phpcs --standard=CognitiveComplexity app`
ERROR: the "CognitiveComplexity" coding standard is not installed. The installed coding standards are MySource, PEAR, PSR1, PSR2, PSR12, Squiz and Zend

**Fix**
To fix it, I had to run this command, with precisely this path:
$ `vendor/bin/phpcs --config-set installed_paths vendor/rarst/phpcs-cognitive-complexity/src/CognitiveComplexity`

To verify the correct setup:
$ `vendor/bin/phpcs -i`
The installed coding standards are MySource, PEAR, PSR1, PSR2, PSR12, Squiz, Zend and CognitiveComplexity